### PR TITLE
Remove `enabled` field from rules

### DIFF
--- a/rules/auth0_breached_password_detection_disabled.yml
+++ b/rules/auth0_breached_password_detection_disabled.yml
@@ -15,7 +15,6 @@ description: |-
       * Disable the application credentials if feasible.
       * Investigate any suspicious activity from the client IP or client ID.
       * Initiate your organization's incident response process.
-enabled: true
 severity: Medium
 query_text: |-
   @scnr.source_type:auth0

--- a/rules/auth0_brute_force_attack_on_user.yml
+++ b/rules/auth0_brute_force_attack_on_user.yml
@@ -2,7 +2,6 @@
 name: Auth0 Brute Force Attack on User
 description: |-
   Detect a potential brute force attack by monitoring failed login attempts from the same Auth0 user.
-enabled: true
 severity: Medium
 query_text: |-
   @scnr.source_type:auth0

--- a/rules/auth0_brute_force_protection_disabled.yml
+++ b/rules/auth0_brute_force_protection_disabled.yml
@@ -15,7 +15,6 @@ description: |-
       * Disable the application credentials if possible.
       * Investigate any further activity from the IP address or the client ID.
       * Initiate your organization's incident response process and investigate further.
-enabled: true
 severity: Medium
 query_text: |-
   @scnr.source_type:auth0

--- a/rules/auth0_cic_credential_stuffing.yml
+++ b/rules/auth0_cic_credential_stuffing.yml
@@ -6,7 +6,6 @@ description: |-
   * `scoa` - Successful cross-origin authentication
   * `fcoa` - Failed cross-origin authentication
   * `pwd_leak` - Someone attempted to login with a breached password
-enabled: true
 severity: High
 query_text: |-
   @scnr.source_type:auth0

--- a/rules/auth0_guardian_mfa_push_notifications_rejected_by_user.yml
+++ b/rules/auth0_guardian_mfa_push_notifications_rejected_by_user.yml
@@ -3,7 +3,6 @@ name: Auth0 Guardian MFA Push Notifications Rejected by User
 description: |-
   Detect when multiple Auth0 Guardian multi-factor authentication (MFA)
   push notifications are rejected by a user.
-enabled: true
 severity: High
 query_text: |-
   @scnr.source_type:auth0

--- a/rules/auth0_integration_installed.yml
+++ b/rules/auth0_integration_installed.yml
@@ -3,7 +3,6 @@ name: Auth0 Integration Installed
 description: |-
   Detect when an integration is installed in Auth0, which may
   introduce security risks.
-enabled: true
 severity: Informational
 query_text: |-
   @scnr.source_type:auth0

--- a/rules/auth0_mfa_factor_setting_enabled.yml
+++ b/rules/auth0_mfa_factor_setting_enabled.yml
@@ -4,7 +4,6 @@ description: |-
   Detect when MFA factor settings are enabled in Auth0. This is typically
   a positive security event but should be monitored to ensure proper
   configuration.
-enabled: true
 severity: Informational
 query_text: |-
   @scnr.source_type:auth0

--- a/rules/auth0_mfa_policy_disabled.yml
+++ b/rules/auth0_mfa_policy_disabled.yml
@@ -3,7 +3,6 @@ name: Auth0 MFA Policy Disabled
 description: |-
   Detect when MFA policies are disabled in Auth0. This can weaken
   security controls and should be monitored closely.
-enabled: true
 severity: High
 query_text: |-
   @scnr.source_type:auth0

--- a/rules/auth0_mfa_policy_enabled.yml
+++ b/rules/auth0_mfa_policy_enabled.yml
@@ -3,7 +3,6 @@ name: Auth0 MFA Policy Enabled
 description: |-
   Detect when MFA policies are enabled in Auth0. This is typically
   a positive security event that strengthens authentication controls.
-enabled: true
 severity: Informational
 query_text: |-
   @scnr.source_type:auth0

--- a/rules/auth0_mfa_risk_assessment_disabled.yml
+++ b/rules/auth0_mfa_risk_assessment_disabled.yml
@@ -3,7 +3,6 @@ name: Auth0 MFA Risk Assessment Disabled
 description: |-
   Detect when MFA risk assessment is disabled in Auth0. This can weaken
   security controls by reducing adaptive authentication capabilities.
-enabled: true
 severity: High
 query_text: |-
   @scnr.source_type:auth0

--- a/rules/auth0_mfa_risk_assessment_enabled.yml
+++ b/rules/auth0_mfa_risk_assessment_enabled.yml
@@ -3,7 +3,6 @@ name: Auth0 MFA Risk Assessment Enabled
 description: |-
   Detect when MFA risk assessment is enabled in Auth0. This is typically
   a positive security event that strengthens adaptive authentication controls.
-enabled: true
 severity: Informational
 query_text: |-
   @scnr.source_type:auth0

--- a/rules/auth0_post_login_trigger_bindings_updated.yml
+++ b/rules/auth0_post_login_trigger_bindings_updated.yml
@@ -3,7 +3,6 @@ name: Auth0 Post-Login Trigger Bindings Updated
 description: |-
   Detect when post-login trigger bindings are updated in Auth0. This can affect
   authentication behavior and should be monitored for security implications.
-enabled: true
 severity: Medium
 query_text: |-
   @scnr.source_type:auth0

--- a/rules/auth0_role_created.yml
+++ b/rules/auth0_role_created.yml
@@ -4,7 +4,6 @@ description: |-
   Detect when a role is created in Auth0. Roles can be used to grant
   specific permissions and should be monitored for potential privilege
   escalation.
-enabled: true
 severity: High
 query_text: |-
   @scnr.source_type:auth0

--- a/rules/auth0_suspicious_ip_throttling_disabled.yml
+++ b/rules/auth0_suspicious_ip_throttling_disabled.yml
@@ -15,7 +15,6 @@ description: |-
       * Disable the application credentials if possible.
       * Investigate any further activity from the IP address or the client ID.
       * Initiate your organization's incident response process and proceed with the investigation.
-enabled: true
 severity: Medium
 query_text: |-
   @scnr.source_type:auth0

--- a/rules/auth0_user_invitation_created.yml
+++ b/rules/auth0_user_invitation_created.yml
@@ -2,7 +2,6 @@
 name: Auth0 User Invitation Created
 description: |-
   Detect when user invitations are created in Auth0 for organizations or tenants.
-enabled: true
 severity: Informational
 query_text: |-
   @scnr.source_type:auth0

--- a/rules/auth0_user_joined_tenant.yml
+++ b/rules/auth0_user_joined_tenant.yml
@@ -2,7 +2,6 @@
 name: Auth0 User Joined Tenant
 description: |-
   Detect when a user joins an Auth0 tenant.
-enabled: true
 severity: Informational
 query_text: |-
   @scnr.source_type:auth0

--- a/rules/auth0_user_logged_in_with_a_breached_password.yml
+++ b/rules/auth0_user_logged_in_with_a_breached_password.yml
@@ -13,7 +13,6 @@ description: |-
   1. Inspect the policy and user location to see if this login is from an approved location.
   2. Verify if two-factor authentication was authenticated.
   3. If the user is compromised, rotate their credentials.
-enabled: true
 severity: Medium
 query_text: |-
   @scnr.source_type:auth0


### PR DESCRIPTION
Support staging state for out-of-the-box rules. The enabled flag should not take precedence when users add rules with staging state.